### PR TITLE
Fix compile errors in cputest.c with gcc 11.3.0

### DIFF
--- a/cputest.c
+++ b/cputest.c
@@ -122,8 +122,8 @@ INLINE tick_t looptest(uint32_t repeats)
 	
 	__asm volatile (
 		"movl %0, %%ecx;"
-		"loop_repeat:"
-		"loop loop_repeat;"
+		"loop_repeat%=:"
+		"loop loop_repeat%=;"
 		: 
 		: "m" (repeats)
 		: "%ecx"


### PR DESCRIPTION
This patch fixes some compile errors in cputest.c with gcc 11.3.0 (NixOS 22.11):

```
gcc -std=gnu99 -g -Wall -Wextra -Wno-unused-parameter -Wno-unused-function -I./mspack -I./system -I./pe -I./nocrt -DPATCHER9X_PATCH=50 -c -o cputest.g.o cputest.c
cputest.c: Assembler messages:
cputest.c:123: Error: symbol `loop_repeat' is already defined
cputest.c:123: Error: symbol `loop_repeat' is already defined
cputest.c:123: Error: symbol `loop_repeat' is already defined
cputest.c:123: Error: symbol `loop_repeat' is already defined
cputest.c:123: Error: symbol `loop_repeat' is already defined
cputest.c:123: Error: symbol `loop_repeat' is already defined
cputest.c:123: Error: symbol `loop_repeat' is already defined
cputest.c:123: Error: symbol `loop_repeat' is already defined
cputest.c:123: Error: symbol `loop_repeat' is already defined
cputest.c:123: Error: value of ffffffffffffff37 too large for field of 1 byte at 0000000000000103
cputest.c:123: Error: value of fffffffffffffedf too large for field of 1 byte at 000000000000015b
cputest.c:123: Error: value of fffffffffffffe83 too large for field of 1 byte at 00000000000001b7
cputest.c:123: Error: value of fffffffffffffe27 too large for field of 1 byte at 0000000000000213
cputest.c:123: Error: value of fffffffffffffdcb too large for field of 1 byte at 000000000000026f
make: *** [Makefile:107: cputest.g.o] Error 1
```