### PR TITLE
Feature: implement GitHub Actions to create patcher9x release artifacts

### DIFF
--- a/.github/workflows/build-patcher9x-builder.yml
+++ b/.github/workflows/build-patcher9x-builder.yml
@@ -1,0 +1,45 @@
+name: Build patcher9x-builder container
+
+on:
+  # Run manually from Actions tab
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}-builder
+
+jobs:
+  build-patcher9x-builder:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: Dockerfile.builder
+          push: true
+          tags: |
+            ${{ steps.meta.outputs.tags }}
+            ${{ env.REGISTRY }}/${{ github.repository }}-builder:latest
+          labels: ${{ steps.meta.outputs.labels }}
+

--- a/.github/workflows/build-patcher9x-release-tag.yml
+++ b/.github/workflows/build-patcher9x-release-tag.yml
@@ -1,0 +1,43 @@
+name: Build patcher9x release
+
+on:
+  # Run manually from Actions tab
+  workflow_dispatch:
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    name: Build patcher9x release
+    container:
+      image: ghcr.io/mcayland/patcher9x-builder:latest
+    steps:
+      - name: Checkout patcher9x
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+
+      - name: Determine release version
+        run: |
+          PATCHER9X_VERSION=`head -n1 CHANGELOG | sed -nz 's/\([0-9\.]\{1,\}\).*/\1/p'`
+          echo "PATCHER9X_VERSION=$PATCHER9X_VERSION" >> $GITHUB_ENV
+
+      - name: Generate release changelog from CHANGELOG
+        # Ignore first line, use following lines up until the next empty line
+        run: |
+          cat CHANGELOG | sed -n '2,/^\r$/ p' > /tmp/release-changelog.txt
+
+      - name: Build patcher9x release
+        run: ./build-release.sh
+
+      - name: Upload patcher9x release
+        uses: softprops/action-gh-release@v2
+        with:
+          token: "${{ secrets.GITHUB_TOKEN }}"
+          name: "v${{ env.PATCHER9X_VERSION }}"
+          tag_name: "v${{ env.PATCHER9X_VERSION }}"
+          body_path: /tmp/release-changelog.txt
+          files: |
+            /tmp/patcher9x-${{ env.PATCHER9X_VERSION }}-boot.ima
+            /tmp/patcher9x-${{ env.PATCHER9X_VERSION }}-linux-amd64.tar.gz
+            /tmp/patcher9x-${{ env.PATCHER9X_VERSION }}-win32.zip
+            /tmp/patcher9x-${{ env.PATCHER9X_VERSION }}-win64.zip

--- a/Dockerfile.builder
+++ b/Dockerfile.builder
@@ -1,0 +1,35 @@
+FROM debian:12 AS djgpp
+
+# Install djgpp build dependencies
+RUN apt-get update && \
+    apt-get install -y bison flex curl gcc g++ make texinfo zlib1g-dev g++ unzip bzip2 xz-utils git
+
+# Download build-djgpp project
+RUN git clone --depth 1 https://github.com/andrewwutw/build-djgpp.git && \
+    cd build-djgpp && \
+    ENABLE_LANGUAGES=c ./build-djgpp.sh 12.2.0
+
+
+FROM debian:12 AS base
+
+# Install mingw-w64 i686 and x86_64 compilers
+RUN apt-get update && \
+    apt-get install -y file wget mtools unzip zip gcc gcc-mingw-w64-i686 gcc-mingw-w64-x86-64 fasm make git
+
+# Install djgpp
+COPY --from=djgpp /usr/local/djgpp /usr/local/djgpp
+
+# Add djgpp to PATH
+ENV PATH /usr/local/djgpp/bin:$PATH
+
+# Install FreeDOS LiteUSB and boot floppy images for boot disk
+RUN mkdir -p /opt/freedos && \
+    wget https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.3/official/FD13-LiteUSB.zip -O /opt/freedos/freedos-liteusb.zip && \
+    wget https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.3/official/FD13-FloppyEdition.zip -O /opt/freedos/freedos-floppy.zip
+
+# Grab CWSDPMI binary
+RUN mkdir -p /opt/cwsdpmi && \
+    wget http://sandmann.dotster.com/cwsdpmi/csdpmi7b.zip -O /opt/cwsdpmi/cwsdpmi.zip
+
+# Assume source in /root
+WORKDIR /root

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,0 +1,142 @@
+#!/bin/sh
+
+#
+# Build release binaries for patcher9x
+#
+# Written by Mark Cave-Ayland <mark.cave-ayland@ilande.co.uk>
+#
+# Builds all of Linux amd64, win32, win64 and DOS boot floppy
+#
+
+# Extract version from the first line of CHANGELOG
+export VERSION=`head -n1 CHANGELOG | sed -nz 's/\([0-9\.]\{1,\}\).*/\1/p'`
+echo "Building release $VERSION"
+
+# Archive vanilla source
+SRCDIR=`pwd`
+tar zcf /tmp/patcher9x.tar.gz .
+
+# Extract archive to build-djgpp and build DOS executable
+rm -rf /tmp/build-djgpp && mkdir -p /tmp/build-djgpp && \
+cd /tmp/build-djgpp && tar xvf /tmp/patcher9x.tar.gz && \
+make RELEASE=1 PROFILE=djgpp && \
+make RELEASE=1 PROFILE=djgpp strip && \
+cd $SRCDIR
+
+# Extract archive to build-win32 and build Win32 executable
+rm -rf /tmp/build-win32 && mkdir -p /tmp/build-win32 && \
+cd /tmp/build-win32 && tar xvf /tmp/patcher9x.tar.gz && \
+make PROFILE=nocrt GUEST_CC=i686-w64-mingw32-gcc RELEASE=1 && \
+make PROFILE=nocrt SUFIX=.exe strip && \
+cd $SRCDIR
+
+# Extract archive to build-win64 and build Win64 executable
+rm -rf /tmp/build-win64 && mkdir -p /tmp/build-win64 && \
+cd /tmp/build-win64 && tar xvf /tmp/patcher9x.tar.gz && \
+make PROFILE=nocrt64 GUEST_CC=x86_64-w64-mingw32-gcc RELEASE=1 && \
+make PROFILE=nocrt64 SUFIX=.exe strip && \
+cd $SRCDIR
+
+# Extract archive to build-amd64 and build Linux executable
+rm -rf /tmp/build-linux-amd64 && mkdir -p /tmp/build-linux-amd64 && \
+cd /tmp/build-linux-amd64 && tar xvf /tmp/patcher9x.tar.gz && \
+make RELEASE=1 && \
+make RELEASE=1 strip && \
+cd $SRCDIR
+
+# Build README.txt from patcher9x help output
+cd /tmp/build-linux-amd64 && PATH=.:$PATH patcher9x -h > /tmp/README.txt && cd $SRCDIR
+
+# Build win32 archive
+mkdir -p /tmp/archive-win32 && \
+cp /tmp/build-win32/patcher9x.exe /tmp/archive-win32 && \
+cp CHANGELOG /tmp/archive-win32/CHANGELOG.txt && \
+cp LICENSE /tmp/archive-win32/LICENCE.txt && \
+cat /tmp/README.txt | sed 's/patcher9x/patcher9x.exe/g' > /tmp/archive-win32/README.txt && \
+cd /tmp/archive-win32 && zip /tmp/patcher9x-$VERSION-win32.zip * && cd $SRCDIR
+
+# Build win64 archive
+mkdir -p /tmp/archive-win64 && \
+cp /tmp/build-win64/patcher9x.exe /tmp/archive-win64 && \
+cp CHANGELOG /tmp/archive-win64/CHANGELOG.txt && \
+cp LICENSE /tmp/archive-win64/LICENCE.txt && \
+cat /tmp/README.txt | sed 's/patcher9x/patcher9x.exe/g' > /tmp/archive-win64/README.txt && \
+cd /tmp/archive-win64 && zip /tmp/patcher9x-$VERSION-win64.zip * && cd $SRCDIR
+
+# Build Linux amd64 archive
+mkdir -p /tmp/archive-linux-amd64 && \
+cp /tmp/build-linux-amd64/patcher9x /tmp/archive-linux-amd64 && \
+cp CHANGELOG /tmp/archive-linux-amd64/CHANGELOG && \
+cp LICENSE /tmp/archive-linux-amd64/LICENCE && \
+cp /tmp/README.txt /tmp/archive-linux-amd64/README && \
+cd /tmp/archive-linux-amd64 && tar zcvf /tmp/patcher9x-$VERSION-linux-amd64.tar.gz * && cd $SRCDIR
+
+# Build boot floppy: extract partition image from LiteUSB edition for extras
+unzip -d /tmp /opt/freedos/freedos-liteusb.zip FD13LITE.img && \
+SS=`file /tmp/FD13LITE.img | sed 's/.*startsector \([0-9]\{1,\}\).*/\1/g'` && \
+mkdir -p /var/lib/dosemu && dd if=/tmp/FD13LITE.img of=/var/lib/dosemu/fdimage skip=$SS
+
+# Copy off boot disk files to /tmp/dosfiles
+mkdir -p /tmp/dosfiles && \
+mmount -V n: && \
+mcopy -pm n:/freedos/bin/XCOPY.EXE /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/COMMAND.COM /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/DELTREE.COM /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/FDISK.EXE /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/FDISK.INI /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/FORMAT.EXE /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/FDISKPT.INI /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/HIMEMX.EXE /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/JEMM386.EXE /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/SHSUCDX.COM /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/UDVD2.SYS /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/DEVLOAD.COM /tmp/dosfiles && \
+mcopy -pm n:/freedos/bin/EDIT.EXE /tmp/dosfiles
+
+# Copy CWSDPMI files to /tmp/dosfiles
+mkdir -p /tmp/cwsdpmi && unzip -d /tmp/cwsdpmi /opt/cwsdpmi/cwsdpmi.zip bin/CWSDPMI.EXE bin/cwsdpmi.doc && \
+cp -p /tmp/cwsdpmi/bin/CWSDPMI.EXE /tmp/dosfiles && \
+cp -p /tmp/cwsdpmi/bin/cwsdpmi.doc /tmp/dosfiles/CWSDPMI.TXT
+
+# Copy PATCH9X.EXE and repo boot files to /tmp/dosfiles
+cp -p /tmp/build-djgpp/patch9x.exe /tmp/dosfiles/PATCH9X.EXE && \
+cp -p boot/autoexec.bat /tmp/dosfiles/AUTOEXEC.BAT && \
+cp -p boot/cdrom.bat /tmp/dosfiles/CDROM.BAT && \
+cp -p boot/fdconfig.sys /tmp/dosfiles/FDCONFIG.SYS && \
+cp -p boot/info.bat /tmp/dosfiles/INFO.BAT && \
+cp -p boot/info.txt /tmp/dosfiles/INFO.TXT && \
+cat boot/readme.txt.template | sed "s/%VERSION%/$VERSION/g" > /tmp/dosfiles/README.TXT
+
+# Finally take the boot floppy, delete the unused files and then copy over ours
+mkdir -p /tmp/floppy && unzip -d /tmp/floppy /opt/freedos/freedos-floppy.zip 144m/x86BOOT.img && \
+cp /tmp/floppy/144m/x86BOOT.img /var/lib/dosemu/fdimage
+
+mdel n:/FDAUTO.BAT && \
+mdel n:/FDCONFIG.SYS && \
+mdel n:/SETUP.BAT && \
+mdeltree n:/FREEDOS && \
+mcopy -pm /tmp/dosfiles/XCOPY.EXE n: && \
+mcopy -pm /tmp/dosfiles/COMMAND.COM n: && \
+mcopy -pm /tmp/dosfiles/DELTREE.COM n: && \
+mcopy -pm /tmp/dosfiles/FDISK.EXE n: && \
+mcopy -pm /tmp/dosfiles/FDISK.INI n: && \
+mcopy -pm /tmp/dosfiles/FORMAT.EXE n: && \
+mcopy -pm /tmp/dosfiles/FDISKPT.INI n: && \
+mcopy -pm /tmp/dosfiles/HIMEMX.EXE n: && \
+mcopy -pm /tmp/dosfiles/JEMM386.EXE n: && \
+mcopy -pm /tmp/dosfiles/SHSUCDX.COM n: && \
+mcopy -pm /tmp/dosfiles/UDVD2.SYS n: && \
+mcopy -pm /tmp/dosfiles/DEVLOAD.COM n: && \
+mcopy -pm /tmp/dosfiles/EDIT.EXE n: && \
+mcopy -pm /tmp/dosfiles/CWSDPMI.EXE n: && \
+mcopy -pm /tmp/dosfiles/CWSDPMI.TXT n: && \
+mcopy -pm /tmp/dosfiles/PATCH9X.EXE n: && \
+mcopy -pm /tmp/dosfiles/AUTOEXEC.BAT n: && \
+mcopy -pm /tmp/dosfiles/CDROM.BAT n: && \
+mcopy -pm /tmp/dosfiles/FDCONFIG.SYS n: && \
+mcopy -pm /tmp/dosfiles/INFO.BAT n: && \
+mcopy -pm /tmp/dosfiles/INFO.TXT n: && \
+mcopy -pm /tmp/dosfiles/README.TXT n:
+
+# Copy the ima file to /tmp
+cp /var/lib/dosemu/fdimage /tmp/patcher9x-$VERSION-boot.ima

--- a/cputest.c
+++ b/cputest.c
@@ -29,7 +29,7 @@
 #include "patcher9x.h"
 
 #if defined(_WIN32)
-#include <Windows.h>
+#include <windows.h>
 /* ^ for QueryPerformanceCounter and QueryPerformanceFrequency */
 #endif
 


### PR DESCRIPTION
Whilst considering if it would be possible to come up with a patch for https://github.com/JHRobotics/patcher9x/issues/23, I found that it wasn't easy to generate a boot floppy for me to test in QEMU, so I set about trying to automate the process.

Using the documentation in the repository, I came up with a `build-release.sh` script to do the hard work, but then figured out it would be much easier to generate a Docker builder image containing all the dependencies, and then use GitHub actions to automate the generation of the release artifacts.

If you would like to see what the results look like, head over to https://github.com/mcayland/patcher9x/ and check out the "Releases" and "Packages" shown to see what gets generated. I've mostly tested the boot floppy in QEMU as that's my particular use case (and my access to real Windows is limited).

### How it works

The series adds a new `Dockerfile.builder` file that creates a builder image containing all of the dependencies required to build patcher9x. This is reasonably straightforward, and makes use of the excellent https://github.com/andrewwutw/build-djgpp project to build a DJGPP cross-compiler. Once that is configured, the FreeDOS boot floppy and LiteUSB images are included to facilitate building of the boot floppy.

Once the builder image has been created, building a release is simply a matter of running the included `build-release.sh` script and then saving the artifacts generated in /tmp. The script makes use of `mtools` to build the boot floppy image as this is a userspace tool and doesn't require granting the build host any special privileges as would be required for loopback mounts. The LiteUSB image is used to supply the majority of the extra programs that aren't include on the boot floppy image.

There is a little bit of magic around generating the README files and extracting the release version, but this is something that can be improved in future. For the moment I just wanted to re-create the existing output artifacts using my build script.

### Getting started

When merged the series adds two new manual GitHub Actions: first of all, run the "Build patcher9x-builder container" action which does the hard work building the DJGPP cross-compiler and installing all the required dependencies. When the action finishes, it generates a new "patcher9x-builder" package visible in the project. **DON'T FORGET TO CONFIGURE secrets.GITHUB_TOKEN FOR THE PATCHER9X REPOSITORY WITH A TOKEN THAT CAN READ THE GIT REPOSITORY AND PUSH TO THE GITHUB PACKAGE REGISTRY**.

Once the "patcher9x-builder" packages has been created, it should be made public by selecting the package, clicking "Package settings" and then "Change visibility" and make the package public. The advantage of this is that it allows users to easily perform build tests locally using the pre-built image, for example:

```
git clone --depth 1 https://github.com/JHRobotics/patcher9x.git
docker run --rm -v $(pwd):/root -i ghcr.io/mcayland/patcher9x-builder <<EOF
  make RELEASE=1 PROFILE=djgpp clean && \
  make RELEASE=1 PROFILE=djgpp && \
  make RELEASE=1 PROFILE=djgpp strip
EOF
```

Updating the builder image is required only very rarely: generally this is only if the base OS or FreeDOS updates are available and desired.

### Generating a release

With all this in place, generating a release is simple: ensure that the latest entry in `CHANGELOG`  is up-to-date, and then manually run the "Build patcher9x release" action. The version number is taken from the first line of `CHANGELOG` and the subsequent text from the 2nd line onwards to the next blank line forms the GitHub release changelog.

### Final preparations before merge

If everything looks good, make sure that you update https://github.com/mcayland/patcher9x/blob/feature/github-actions/.github/workflows/build-patcher9x-release-tag.yml#L12 to point to the upstream `ghcr.io/JHRobotics/patcher9x-builder:latest` builder image **BEFORE MERGE**.
